### PR TITLE
update base64 from 0.21 to 0.22; zip from 0.6 to 2.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [".", "api"]
 default-members = [".", "api"]
 
 [workspace.dependencies]
-base64 = "0.21"
+base64 = "0.22"
 clap = { version = "4", features = ["derive"] }
 ed25519-dalek = { version = "2", features = ["digest"] }
 normalize-path = "0.2"
@@ -21,7 +21,7 @@ pretty-error-debug = "0.3"
 rand_core = { version = "0.6", features = ["getrandom"] }
 tempfile = "3"
 thiserror = "1"
-zip = { version = "0.6", default-features = false }
+zip = { version = "2", default-features = false }
 
 [workspace.dependencies.zipsign-api]
 version = "0.1.1"

--- a/api/src/sign_unsign_zip.rs
+++ b/api/src/sign_unsign_zip.rs
@@ -25,7 +25,7 @@ where
     let mut input = ZipArchive::new(BufReader::new(input)).map_err(CopyZipError::InputZip)?;
     let mut output = ZipWriter::new(BufWriter::new(output));
 
-    output.set_raw_comment(input.comment().to_owned().into());
+    output.set_raw_comment(input.comment().into());
     for idx in 0..input.len() {
         let file = input
             .by_index_raw(idx)

--- a/api/src/sign_unsign_zip.rs
+++ b/api/src/sign_unsign_zip.rs
@@ -25,7 +25,7 @@ where
     let mut input = ZipArchive::new(BufReader::new(input)).map_err(CopyZipError::InputZip)?;
     let mut output = ZipWriter::new(BufWriter::new(output));
 
-    output.set_raw_comment(input.comment().to_owned());
+    output.set_raw_comment(input.comment().to_owned().into());
     for idx in 0..input.len() {
         let file = input
             .by_index_raw(idx)


### PR DESCRIPTION
@Kijewski , zip now has new maintainers, and the latest zip has a lot of bug fixes and perf optimizations

cc @Pr0methean